### PR TITLE
completed namespacing for vehicles and modules

### DIFF
--- a/app/controllers/api/v1/pv_modules_controller.rb
+++ b/app/controllers/api/v1/pv_modules_controller.rb
@@ -10,8 +10,9 @@ class Api::V1::PvModulesController < ApplicationController
 
   def create
     @pv_module = PvModule.new(pv_module_params)
+    branch = Branch.find(params['branch_id'])
+    @pv_module.branch_id = branch.id
     if @pv_module.save
-      BranchPvModule.create(pv_module: @pv_module, branch_id: branch_params[:id])
       render json: "PV Module was successfully created!"
     else
       render json: "PV Module was not created, please try again"
@@ -38,9 +39,9 @@ class Api::V1::PvModulesController < ApplicationController
       params.require(:pv_module).permit(:output_w, :efficiency, :manufacturer, :model, :width_mm, :length_mm)
     end
 
-    def branch_params
-      params.require(:branch).permit(:id)
-    end
+    # def branch_params
+    #   params.require(:branch).permit(:id)
+    # end
 
 
 end

--- a/app/controllers/api/v1/vehicles_controller.rb
+++ b/app/controllers/api/v1/vehicles_controller.rb
@@ -10,8 +10,9 @@ class Api::V1::VehiclesController < ApplicationController
 
   def create
     @vehicle = Vehicle.new(vehicle_params)
+    branch = Branch.find(params['branch_id'])
+    @vehicle.branch_id = branch.id
     if @vehicle.save
-      # BranchVehicle.create(branch: vehicle_params[:user_id], vehicle: @vehicle)
       render json: "Vehicle was successfully created!"
     else
       render json: "Vehicle was not created, please try again"

--- a/app/models/branch.rb
+++ b/app/models/branch.rb
@@ -1,7 +1,7 @@
 class Branch < ApplicationRecord
   validates_presence_of :street, :city, :state, :zipcode
   has_many :projects
-  has_many :branch_vehicles
-  has_many :vehicles, through: :branch_vehicles
+  has_many :pv_modules
+  has_many :vehicles
 
 end

--- a/app/models/pv_module.rb
+++ b/app/models/pv_module.rb
@@ -1,7 +1,6 @@
 class PvModule < ApplicationRecord
   validates_presence_of :output_w, :manufacturer, :model, :width_mm, :length_mm
   has_many :projects
-  has_many :branch_pv_modules
-  has_many :branches, through: :branch_pv_modules
+  belongs_to :branch
 
 end

--- a/app/models/vehicle.rb
+++ b/app/models/vehicle.rb
@@ -1,7 +1,6 @@
 class Vehicle < ApplicationRecord
-  validates_presence_of :make, :model, :mpg
-  has_many :branch_vehicles
-  has_many :branches, through: :branch_vehicles
+  validates_presence_of :make, :model, :mpg, :branch_id
+  belongs_to :branch
   has_many :project_vehicles
   has_many :projects, through: :project_vehicles
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,9 @@ Rails.application.routes.draw do
       namespace :v1 do
         resources "branches", only: [:create, :update, :index, :show, :destroy] do
           resources "projects", only: [:create, :update, :index, :show, :destroy]
+          resources "vehicles", only: [:create, :update, :index, :show, :destroy]
+          resources "pv_modules", only: [:create, :update, :index, :show, :destroy]
         end
-        resources "vehicles", only: [:create, :update, :index, :show, :destroy]
-        resources "pv_modules", only: [:create, :update, :index, :show, :destroy]
     end
   end
 end

--- a/db/migrate/20180404201955_create_pv_modules.rb
+++ b/db/migrate/20180404201955_create_pv_modules.rb
@@ -7,6 +7,7 @@ class CreatePvModules < ActiveRecord::Migration[5.1]
       t.string :model
       t.integer :width_mm
       t.integer :length_mm
+      t.references :branch, foreign_key: true
     end
   end
 end

--- a/db/migrate/20180404202347_create_vehicles.rb
+++ b/db/migrate/20180404202347_create_vehicles.rb
@@ -4,6 +4,7 @@ class CreateVehicles < ActiveRecord::Migration[5.1]
       t.string :make
       t.string :model
       t.integer :mpg
+      t.references :branch, foreign_key: true
     end
   end
 end

--- a/db/migrate/20180404202435_create_branch_vehicles.rb
+++ b/db/migrate/20180404202435_create_branch_vehicles.rb
@@ -1,8 +1,0 @@
-class CreateBranchVehicles < ActiveRecord::Migration[5.1]
-  def change
-    create_table :branch_vehicles do |t|
-      t.references :branch, foreign_key: true
-      t.references :vehicle, foreign_key: true
-    end
-  end
-end

--- a/db/migrate/20180406144824_create_branch_pv_modules.rb
+++ b/db/migrate/20180406144824_create_branch_pv_modules.rb
@@ -1,8 +1,0 @@
-class CreateBranchPvModules < ActiveRecord::Migration[5.1]
-  def change
-    create_table :branch_pv_modules do |t|
-      t.references :branch, foreign_key: true
-      t.references :pv_module, foreign_key: true
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,30 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180406144824) do
+ActiveRecord::Schema.define(version: 20180404202710) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "branch_pv_modules", force: :cascade do |t|
-    t.bigint "branch_id"
-    t.bigint "pv_module_id"
-    t.index ["branch_id"], name: "index_branch_pv_modules_on_branch_id"
-    t.index ["pv_module_id"], name: "index_branch_pv_modules_on_pv_module_id"
-  end
 
   create_table "branch_users", force: :cascade do |t|
     t.bigint "branch_id"
     t.bigint "user_id"
     t.index ["branch_id"], name: "index_branch_users_on_branch_id"
     t.index ["user_id"], name: "index_branch_users_on_user_id"
-  end
-
-  create_table "branch_vehicles", force: :cascade do |t|
-    t.bigint "branch_id"
-    t.bigint "vehicle_id"
-    t.index ["branch_id"], name: "index_branch_vehicles_on_branch_id"
-    t.index ["vehicle_id"], name: "index_branch_vehicles_on_vehicle_id"
   end
 
   create_table "branches", force: :cascade do |t|
@@ -79,6 +65,8 @@ ActiveRecord::Schema.define(version: 20180406144824) do
     t.string "model"
     t.integer "width_mm"
     t.integer "length_mm"
+    t.bigint "branch_id"
+    t.index ["branch_id"], name: "index_pv_modules_on_branch_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -92,16 +80,16 @@ ActiveRecord::Schema.define(version: 20180406144824) do
     t.string "make"
     t.string "model"
     t.integer "mpg"
+    t.bigint "branch_id"
+    t.index ["branch_id"], name: "index_vehicles_on_branch_id"
   end
 
-  add_foreign_key "branch_pv_modules", "branches"
-  add_foreign_key "branch_pv_modules", "pv_modules"
   add_foreign_key "branch_users", "branches"
   add_foreign_key "branch_users", "users"
-  add_foreign_key "branch_vehicles", "branches"
-  add_foreign_key "branch_vehicles", "vehicles"
   add_foreign_key "project_vehicles", "projects"
   add_foreign_key "project_vehicles", "vehicles"
   add_foreign_key "projects", "branches"
   add_foreign_key "projects", "pv_modules"
+  add_foreign_key "pv_modules", "branches"
+  add_foreign_key "vehicles", "branches"
 end

--- a/spec/factories/pv_module.rb
+++ b/spec/factories/pv_module.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     efficiency 0.18
     width_mm 997
     length_mm 1675
+    branch
   end
 end

--- a/spec/factories/vehicle.rb
+++ b/spec/factories/vehicle.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     make "Mercedes"
     model "Sprinter"
     mpg 20
+    branch
   end
 end

--- a/spec/requests/api/v1/module_requests_spec.rb
+++ b/spec/requests/api/v1/module_requests_spec.rb
@@ -4,10 +4,12 @@ describe "Modules API" do
   context "HTTP GET all" do
     it "sends a list of pv_modules" do
       VCR.use_cassette("get_all_pv_modules") do
+        branch = create(:branch)
+        create(:pv_module, branch: branch)
+        create(:pv_module, branch: branch)
+        create(:pv_module, branch: branch)
 
-        create_list(:pv_module, 3)
-
-        get '/api/v1/pv_modules'
+        get "/api/v1/branches/#{branch.id}/pv_modules"
 
         expect(response).to be_success
 
@@ -21,11 +23,12 @@ describe "Modules API" do
   context "HTTP GET one" do
     it "sends a single pv_module" do
       VCR.use_cassette("get_one_pv_modules") do
-        pv_module = create(:pv_module, model: "TP 275w")
-        create(:pv_module, model: "TP 260w")
-        create(:pv_module, model: "TP 280w")
+        branch = create(:branch)
+        pv_module = create(:pv_module, model: "TP 275w", branch: branch)
+        create(:pv_module, model: "TP 260w", branch: branch)
+        create(:pv_module, model: "TP 280w", branch: branch)
 
-        get "/api/v1/pv_modules/#{pv_module.id}"
+        get "/api/v1/branches/#{branch.id}/pv_modules/#{pv_module.id}"
 
         expect(response).to be_success
 
@@ -43,12 +46,12 @@ describe "Modules API" do
 
         expect(PvModule.all.count).to eq(0)
 
-        post "/api/v1/pv_modules?pv_module[output%5Fw]=250&pv_module[manufacturer]=REC&pv_module[model]=250%20TP&pv_module[efficiency]=0%2E18&pv_module[width_mm]=997&pv_module[length_mm]=1675&branch[id]=#{branch.id}"
+        post "/api/v1/branches/#{branch.id}/pv_modules?pv_module[output%5Fw]=250&pv_module[manufacturer]=REC&pv_module[model]=250%20TP&pv_module[efficiency]=0%2E18&pv_module[width_mm]=997&pv_module[length_mm]=1675"
 
         expect(response).to be_success
         expect(response.body).to eq("PV Module was successfully created!")
         expect(PvModule.all.count).to eq(1)
-        expect(BranchPvModule.all.count).to eq(1)
+        expect(branch.pv_modules.count).to eq(1)
         expect(PvModule.first.model).to eq("250 TP")
       end
     end
@@ -57,10 +60,11 @@ describe "Modules API" do
   context "HTTP PATCH" do
     it "updates an existing pv_module" do
       VCR.use_cassette("update_a_pv_modules") do
-        pv_module = create(:pv_module)
+        branch = create(:branch)
+        pv_module = create(:pv_module, branch: branch)
         expect(pv_module.manufacturer).to eq("REC")
 
-        patch "/api/v1/pv_modules/#{pv_module.id}?pv_module[manufacturer]=Sungevity"
+        patch "/api/v1/branches/#{branch.id}/pv_modules/#{pv_module.id}?pv_module[manufacturer]=Sungevity"
 
         expect(response).to be_success
         new_pv_module = JSON.parse(response.body)
@@ -74,12 +78,13 @@ describe "Modules API" do
     it "deletes an existing pv_module" do
       VCR.use_cassette("delete_a_pv_module") do
         expect(PvModule.all.count).to eq(0)
-        pv_module_1 = create(:pv_module, manufacturer: "REC")
-        pv_module_2 = create(:pv_module, manufacturer: "Sungevity")
+        branch = create(:branch)
+        pv_module_1 = create(:pv_module, manufacturer: "REC", branch: branch)
+        pv_module_2 = create(:pv_module, manufacturer: "Sungevity", branch: branch)
 
         expect(PvModule.all.count).to eq(2)
 
-        delete "/api/v1/pv_modules/#{pv_module_2.id}"
+        delete "/api/v1/branches/#{branch.id}/pv_modules/#{pv_module_2.id}"
 
         expect(response).to be_success
         expect(response.body).to eq("PV Module was successfully deleted!")

--- a/spec/requests/api/v1/vehicle_requests_spec.rb
+++ b/spec/requests/api/v1/vehicle_requests_spec.rb
@@ -3,9 +3,12 @@ require 'rails_helper'
 describe "Vehicles API" do
   context "HTTP GET all" do
     it "sends a list of vehicles" do
-      create_list(:vehicle, 3)
+      branch = create(:branch)
+      create(:vehicle, branch: branch)
+      create(:vehicle, branch: branch)
+      create(:vehicle, branch: branch)
 
-      get '/api/v1/vehicles'
+      get "/api/v1/branches/#{branch.id}/vehicles"
 
       expect(response).to be_success
 
@@ -17,11 +20,12 @@ describe "Vehicles API" do
 
   context "HTTP GET one" do
     it "sends a list of vehicles" do
-      vehicle_1 = create(:vehicle, make: "Toyota")
-      create(:vehicle, make: "Mercedes")
-      create(:vehicle, make: "Honda")
+      branch = create(:branch)
+      vehicle_1 = create(:vehicle, make: "Toyota", branch: branch)
+      create(:vehicle, make: "Mercedes", branch: branch)
+      create(:vehicle, make: "Honda", branch: branch)
 
-      get "/api/v1/vehicles/#{vehicle_1.id}"
+      get "/api/v1/branches/#{branch.id}/vehicles/#{vehicle_1.id}"
 
       expect(response).to be_success
 
@@ -33,24 +37,26 @@ describe "Vehicles API" do
 
   context "HTTP POST" do
     it "creates a new vehicle" do
-
+      branch = create(:branch)
       expect(Vehicle.all.count).to eq(0)
 
-      post "/api/v1/vehicles?vehicle[make]=Ford&vehicle[model]=fusion&vehicle[mpg]=35"
+      post "/api/v1/branches/#{branch.id}/vehicles?vehicle[make]=Ford&vehicle[model]=fusion&vehicle[mpg]=35"
 
       expect(response).to be_success
       expect(response.body).to eq("Vehicle was successfully created!")
       expect(Vehicle.all.count).to eq(1)
+      expect(branch.vehicles.count).to eq(1)
       expect(Vehicle.first.make).to eq("Ford")
     end
   end
 
   context "HTTP PATCH" do
     it "updates an existing vehicle" do
-      vehicle = create(:vehicle)
+      branch = create(:branch)
+      vehicle = create(:vehicle, branch: branch)
       expect(vehicle.make).to eq("Mercedes")
 
-      patch "/api/v1/vehicles/#{vehicle.id}?vehicle[make]=Toyota"
+      patch "/api/v1/branches/#{branch.id}/vehicles/#{vehicle.id}?vehicle[make]=Toyota"
 
       expect(response).to be_success
       new_vehicle = JSON.parse(response.body)
@@ -61,13 +67,14 @@ describe "Vehicles API" do
 
   context "HTTP Delete" do
     it "deletes an existing vehicle" do
+      branch = create(:branch)
       expect(Vehicle.all.count).to eq(0)
-      vehicle_1 = create(:vehicle, make: "22 Hunter Way")
-      vehicle_2 = create(:vehicle, make: "5505 Pleasing Palace Place")
+      vehicle_1 = create(:vehicle, make: "22 Hunter Way", branch: branch)
+      vehicle_2 = create(:vehicle, make: "5505 Pleasing Palace Place", branch: branch)
 
       expect(Vehicle.all.count).to eq(2)
 
-      delete "/api/v1/vehicles/#{vehicle_2.id}"
+      delete "/api/v1/branches/#{branch.id}/vehicles/#{vehicle_2.id}"
 
       expect(response).to be_success
       expect(response.body).to eq("Vehicle was successfully deleted!")


### PR DESCRIPTION
Altered schema to add branch references modules and vehicles rather than joins table objects. Rather than add additional migration files, the db was rolled back and needs to be reset on production side.